### PR TITLE
fix: Fix convenience script

### DIFF
--- a/hack/autoinstall.sh
+++ b/hack/autoinstall.sh
@@ -22,7 +22,7 @@ detect_package_suffix() {
 # Function to get the latest release tag from GitHub
 get_latest_release() {
     local repo="$1"
-    curl -s "https://api.github.com/repos/$repo/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
+    curl -Ls "https://api.github.com/repos/$repo/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
 }
 
 github_repo="uptime-lab/computeblade-agent"


### PR DESCRIPTION
Issue: `curl` is missing a parameter to follow redirects.

```bash
curl -s "https://api.github.com/repos/uptime-lab/computeblade-agent/releases/latest"
{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/661558995/releases/latest",
  "documentation_url": "https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"
}
```

Solution:

```bash
curl -s -L "https://api.github.com/repos/uptime-lab/computeblade-agent/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
v0.5.0

```