### PR TITLE
fix: Follow GitHub redirects when finding the latest version

### DIFF
--- a/hack/autoinstall.sh
+++ b/hack/autoinstall.sh
@@ -22,7 +22,7 @@ detect_package_suffix() {
 # Function to get the latest release tag from GitHub
 get_latest_release() {
     local repo="$1"
-    curl -s "https://api.github.com/repos/$repo/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
+    curl -s -L "https://api.github.com/repos/$repo/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
 }
 
 github_repo="uptime-lab/computeblade-agent"


### PR DESCRIPTION
fix: Follow GitHub redirects when finding the latest version.

GitHub has started to return 301 responses when we ask for the latest version. However, this location is the one location we fail to follow redirects. We should follow their guidance (https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api#follow-redirects%22)

```
jbirch@pitest:~ $ repo="uptime-lab/computeblade-agent"
jbirch@pitest:~ $ curl -w "Return Code: %{http_code}\n" "https://api.github.com/repos/$repo/releases/latest"
{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/661558995/releases/latest",
  "documentation_url": "https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"
}
Return Code: 301
```

Fixes #35.