### PR TITLE
fix: correct package name from computeblade-agent to compute-blade-agent

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
         id: release-please
         with:
           release-type: simple  # actual releasing is handled by goreleaser
-          package-name: computeblade-agent
+          package-name: compute-blade-agent
     outputs:
       release_created: ${{ steps.release-please.outputs.release_created }}
 

--- a/cmd/agent/default-config.yaml
+++ b/cmd/agent/default-config.yaml
@@ -1,4 +1,4 @@
-# Default configuration for the computeblade-agent
+# Default configuration for the compute-blade-agent
 
 log:
   mode: production  # production, development
@@ -6,7 +6,7 @@ log:
 # Listen configuration
 listen:
   metrics: ":9666"
-  grpc: /tmp/computeblade-agent.sock
+  grpc: /tmp/compute-blade-agent.sock
 
 # Hardware abstraction layer configuration
 hal:

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -34,7 +34,7 @@ func main() {
 	viper.AutomaticEnv()
 	viper.SetConfigName("config")
 	viper.SetConfigType("yaml")
-	viper.AddConfigPath("/etc/computeblade-agent")
+	viper.AddConfigPath("/etc/compute-blade-agent")
 
 	// Load potential file configs
 	if err := viper.ReadInConfig(); err != nil {
@@ -52,7 +52,7 @@ func main() {
 		panic(fmt.Errorf("invalid log.mode: %s", logMode))
 	}
 
-	zapLogger := baseLogger.With(zap.String("app", "computeblade-agent"))
+	zapLogger := baseLogger.With(zap.String("app", "compute-blade-agent"))
 	defer func() {
 		_ = zapLogger.Sync()
 	}()
@@ -84,7 +84,7 @@ func main() {
 		}
 	}()
 
-	log.FromContext(ctx).Info("Bootstrapping computeblade-agent", zap.String("version", viper.GetString("version")))
+	log.FromContext(ctx).Info("Bootstrapping compute-blade-agent", zap.String("version", viper.GetString("version")))
 	computebladeAgent, err := agent.NewComputeBladeAgent(ctx, cbAgentConfig)
 	if err != nil {
 		log.FromContext(ctx).Error("Failed to create agent", zap.Error(err))

--- a/cmd/bladectl/cmd_identify.go
+++ b/cmd/bladectl/cmd_identify.go
@@ -40,7 +40,7 @@ func runIdentity(cmd *cobra.Command, _ []string) error {
 		event = bladeapiv1alpha1.Event_IDENTIFY_CONFIRM
 	}
 
-	// Emit the event to the computeblade-agent
+	// Emit the event to the compute-blade-agent
 	_, err = client.EmitEvent(ctx, &bladeapiv1alpha1.EmitEventRequest{Event: event})
 	if err != nil {
 		return err

--- a/cmd/bladectl/main.go
+++ b/cmd/bladectl/main.go
@@ -29,7 +29,7 @@ var (
 
 func init() {
 	rootCmd.PersistentFlags().
-		StringVar(&grpcAddr, "addr", "unix:///tmp/computeblade-agent.sock", "address of the computeblade-agent gRPC server")
+		StringVar(&grpcAddr, "addr", "unix:///tmp/compute-blade-agent.sock", "address of the compute-blade-agent gRPC server")
 	rootCmd.PersistentFlags().DurationVar(&timeout, "timeout", time.Minute, "timeout for gRPC requests")
 }
 
@@ -47,7 +47,7 @@ func clientFromContext(ctx context.Context) bladeapiv1alpha1.BladeAgentServiceCl
 
 var rootCmd = &cobra.Command{
 	Use:   "bladectl",
-	Short: "bladectl interacts with the computeblade-agent and allows you to manage hardware-features of your compute blade(s)",
+	Short: "bladectl interacts with the compute-blade-agent and allows you to manage hardware-features of your compute blade(s)",
 	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 		origCtx := cmd.Context()
 

--- a/hack/systemd/compute-blade-agent.service
+++ b/hack/systemd/compute-blade-agent.service
@@ -5,7 +5,7 @@ After=network.target
 
 [Service]
 Restart=on-failure
-ExecStart=/usr/bin/computeblade-agent
+ExecStart=/usr/bin/compute-blade-agent
 TimeoutStopSec=20s
 
 [Install]


### PR DESCRIPTION
In the course of the project the name was changed from “computeblade-agent” to “compute-blade-agent”. this was not consistent and version 0.5.6 was therefore not usable. this mergerequest has corrected the corresponding places. 

Fix #46

I also adjusted the autoinstall script so that the download works again.

Fix #45