### PR TITLE
fix: goreleaser issues

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
       # Setup tinygo
       - uses: acifani/setup-tinygo@v2
         with:
-          tinygo-version: '0.33.0'
+          tinygo-version: '0.37.0'
 
       # Setup docker buildx
       - name: Set up QEMU

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,9 +38,9 @@ dockers:
     - agent
     - bladectl
     image_templates:
-      - ghcr.io/github.com/uptime-industries/compute-blade-agent:latest
-      - ghcr.io/github.com/uptime-industries/compute-blade-agent:{{ .Tag }}
-      - ghcr.io/github.com/uptime-industries/compute-blade-agent:v{{ .Major }}
+      - ghcr.io/uptime-industries/compute-blade-agent:latest
+      - ghcr.io/uptime-industries/compute-blade-agent:{{ .Tag }}
+      - ghcr.io/uptime-industries/compute-blade-agent:v{{ .Major }}
     build_flag_templates:
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
@@ -79,7 +79,7 @@ nfpms:
 - id: compute-blade-agent
   maintainer: Matthias Riegler <me@xvzf.tech>
   description: compute-blade Agent
-  homepage: https://github.com/github.com/uptime-industries/compute-blade-agent
+  homepage: https://github.com/uptime-industries/compute-blade-agent
   license: Apache 2.0
   formats:
   - deb


### PR DESCRIPTION
- Removing the `github.com` segment from the URLs as this is not meant to be there.
- upgrade the tinygo version