### PR TITLE
fix(systemd): Add User to systemd service to prevent failure during startup

### DIFF
--- a/hack/systemd/compute-blade-agent.service
+++ b/hack/systemd/compute-blade-agent.service
@@ -4,6 +4,7 @@ Documentation=https://github.com/uptime-industries/compute-blade-agent
 After=network.target
 
 [Service]
+User=root
 Restart=on-failure
 ExecStart=/usr/bin/compute-blade-agent
 TimeoutStopSec=20s


### PR DESCRIPTION
Currently, the compute-blade-agent fails to start:

```log
May 28 12:56:02 blade-pi1 compute-blade-agent[2066699]: {"level":"fatal","ts":1748433362.147768,"caller":"agent/main.go:104","msg":"Failed to create agent","app":"compute-blade-agent","error":"Failed to extract home directory"}
```

This is a result of #54 being tested with a locally modified systemd service file that had the user ecplicitly set.

In #54 a dependency to the user home directory was made to store the `bladectl` configuration file. If the systemd-service unit runs without an explicit user set, `os.UserHomeDir()` will return `err` preventing the agent from starting up